### PR TITLE
fix: update upload-pages-artifact version

### DIFF
--- a/.github/workflows/nuxtjs.yml
+++ b/.github/workflows/nuxtjs.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Static HTML export with Nuxt
         run: ${{ steps.detect-package-manager.outputs.manager }} run generate
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
       - name: Deploy to Github Pages


### PR DESCRIPTION
fix github action run failed.

```
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```